### PR TITLE
Check some invalid conditions

### DIFF
--- a/Software/PC_Application/CustomWidgets/siunitedit.cpp
+++ b/Software/PC_Application/CustomWidgets/siunitedit.cpp
@@ -5,6 +5,7 @@
 #include <QEvent>
 #include <QKeyEvent>
 #include <QDebug>
+#include <QTimer>
 
 SIUnitEdit::SIUnitEdit(QString unit, QString prefixes, int precision, QWidget *parent)
     : QLineEdit(parent)
@@ -83,6 +84,16 @@ bool SIUnitEdit::eventFilter(QObject *, QEvent *event)
     } else if(event->type() == QEvent::FocusOut) {
         parseNewValue(1.0);
         emit focusLost();
+    } else if(event->type() == QEvent::FocusIn) {
+        // online found clumsy way to select all text when clicked!?!
+        // just selectAll() alone does _not_ work!
+        QTimer::singleShot(0, this, &QLineEdit::selectAll);
+        /*
+         * However, this widget does not loose focus when clicking on a smith chart from here
+         * At the same time, clicking on x-y plot does loose focus as expected
+         * This behaviour existed before this mod, but it was not obvious due to properties of placeholdertext
+         */
+
     }
     return false;
 }
@@ -91,7 +102,8 @@ void SIUnitEdit::setValueQuiet(double value)
 {
     _value = value;
     clear();
-    setPlaceholderText(Unit::ToString(value, unit, prefixes, precision));
+    setPlaceholderText(Unit::ToString(value, unit, prefixes, precision)); // didn't remove it because maybe needed elsewhere
+    setText(Unit::ToString(value, unit, prefixes, precision));   // because selectAll() only affects setText() (placeholder text is igonred)
 }
 
 void SIUnitEdit::parseNewValue(double factor)
@@ -118,7 +130,7 @@ void SIUnitEdit::parseNewValue(double factor)
         } else {
             qWarning() << "SIUnit conversion failure:" << input;
         }
-        clear();
+//        clear();  // removed due to funny behaviour when clicking repeatedly between start, center, span, stop, but without editing anything
     }
 }
 

--- a/Software/PC_Application/Traces/markerwidget.cpp
+++ b/Software/PC_Application/Traces/markerwidget.cpp
@@ -12,9 +12,9 @@ MarkerWidget::MarkerWidget(TraceMarkerModel &model, QWidget *parent) :
     ui->treeView->setItemDelegateForColumn(TraceMarkerModel::ColIndexType, new MarkerTypeDelegate);
     ui->treeView->setItemDelegateForColumn(TraceMarkerModel::ColIndexSettings, new MarkerSettingsDelegate);
 
-    ui->treeView->setColumnWidth(TraceMarkerModel::ColIndexNumber, 80);
-    ui->treeView->setColumnWidth(TraceMarkerModel::ColIndexTrace, 80);
-    ui->treeView->setColumnWidth(TraceMarkerModel::ColIndexType, 150);
+    ui->treeView->setColumnWidth(TraceMarkerModel::ColIndexNumber, 60); // reduced width to fit widget when App is not maximized
+    ui->treeView->setColumnWidth(TraceMarkerModel::ColIndexTrace, 60);  // reduced width to fit widget when App is not maximized
+    ui->treeView->setColumnWidth(TraceMarkerModel::ColIndexType, 120);  // reduced width to fit widget when App is not maximized
 
     connect(&model.getModel(), &TraceModel::traceAdded, this, &MarkerWidget::updatePersistentEditors);
     connect(&model.getModel(), &TraceModel::traceRemoved, this, &MarkerWidget::updatePersistentEditors);
@@ -31,7 +31,17 @@ MarkerWidget::~MarkerWidget()
 
 void MarkerWidget::on_bDelete_clicked()
 {
-    auto marker = model.markerFromIndex(ui->treeView->currentIndex());
+    if (model.rowCount() <= 0) {
+        return;                 // prevent crash if bDelete clicked with no markers (empty model)
+    }
+
+    QModelIndex ind = ui->treeView->currentIndex();
+    if ( ! ind.isValid() ) {
+        return;     // add marker(s), then click bDelete without clicking on any marker (there is no index clicked in treeView)
+                    // alternative: select last marker, then proceede to delete it?
+    }
+
+    auto marker = model.markerFromIndex(ind);
     if(!marker || marker->getParent()) {
         // can't delete child markers directly
         return;

--- a/Software/PC_Application/Traces/tracewidget.cpp
+++ b/Software/PC_Application/Traces/tracewidget.cpp
@@ -36,7 +36,11 @@ void TraceWidget::on_add_clicked()
 
 void TraceWidget::on_remove_clicked()
 {
-    model.removeTrace(ui->view->currentIndex().row());
+    QModelIndex index = ui->view->currentIndex();
+    if (index.isValid()) {      // if nothing clicked, index.row() = -1
+        model.removeTrace(index.row());
+        // otherwise, TraceModel casts index to unsigned int and compares with traces.size() which is int
+    };
 }
 
 bool TraceWidget::eventFilter(QObject *, QEvent *event)

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -171,9 +171,10 @@ VNA::VNA(AppWindow *window)
 
 
     // Sweep toolbar
+    int wid = 80;   // propose slight reduction, to fit more widgets comfortably
     auto tb_sweep = new QToolBar("Sweep");
     auto eStart = new SIUnitEdit("Hz", " kMG", 6);
-    eStart->setFixedWidth(100);
+    eStart->setFixedWidth(wid);
     eStart->setToolTip("Start frequency");
     connect(eStart, &SIUnitEdit::valueChanged, this, &VNA::SetStartFreq);
     connect(this, &VNA::startFreqChanged, eStart, &SIUnitEdit::setValueQuiet);
@@ -181,7 +182,7 @@ VNA::VNA(AppWindow *window)
     tb_sweep->addWidget(eStart);
 
     auto eCenter = new SIUnitEdit("Hz", " kMG", 6);
-    eCenter->setFixedWidth(100);
+    eCenter->setFixedWidth(wid);
     eCenter->setToolTip("Center frequency");
     connect(eCenter, &SIUnitEdit::valueChanged, this, &VNA::SetCenterFreq);
     connect(this, &VNA::centerFreqChanged, eCenter, &SIUnitEdit::setValueQuiet);
@@ -189,7 +190,7 @@ VNA::VNA(AppWindow *window)
     tb_sweep->addWidget(eCenter);
 
     auto eStop = new SIUnitEdit("Hz", " kMG", 6);
-    eStop->setFixedWidth(100);
+    eStop->setFixedWidth(wid);
     eStop->setToolTip("Stop frequency");
     connect(eStop, &SIUnitEdit::valueChanged, this, &VNA::SetStopFreq);
     connect(this, &VNA::stopFreqChanged, eStop, &SIUnitEdit::setValueQuiet);
@@ -197,7 +198,7 @@ VNA::VNA(AppWindow *window)
     tb_sweep->addWidget(eStop);
 
     auto eSpan = new SIUnitEdit("Hz", " kMG", 6);
-    eSpan->setFixedWidth(100);
+    eSpan->setFixedWidth(wid);
     eSpan->setToolTip("Span");
     connect(eSpan, &SIUnitEdit::valueChanged, this, &VNA::SetSpan);
     connect(this, &VNA::spanChanged, eSpan, &SIUnitEdit::setValueQuiet);
@@ -225,7 +226,7 @@ VNA::VNA(AppWindow *window)
     // Acquisition toolbar
     auto tb_acq = new QToolBar("Acquisition");
     auto dbm = new QDoubleSpinBox();
-    dbm->setFixedWidth(95);
+    dbm->setFixedWidth(80); // propose slight reduction, to fit more widgets when App not maximized
     dbm->setRange(-100.0, 100.0);
     dbm->setSingleStep(0.25);
     dbm->setSuffix("dbm");


### PR DESCRIPTION
Hi Jan!
Here are some of my suggestions.

Noticed some invalid conditions which could cause a crash.

Proposed some cosmetic changes. At least on my favourite monitor(s) (1600x1200, 1600x900), can fit all toolbars without maximizing the app. Depends how you like it...

Propose to selectAll() in siunitedit, to keep text visible upon gaining focus.