### PR TITLE
SignalGen - more precision digits; ui panel mod.

### DIFF
--- a/Software/PC_Application/Generator/signalgenwidget.cpp
+++ b/Software/PC_Application/Generator/signalgenwidget.cpp
@@ -8,6 +8,7 @@ SignalgeneratorWidget::SignalgeneratorWidget(QWidget *parent) :
     ui->setupUi(this);
     ui->frequency->setUnit("Hz");
     ui->frequency->setPrefixes(" kMG");
+    ui->frequency->setPrecision(6); // show enough digits
 
     connect(ui->frequency, &SIUnitEdit::valueChanged, [=](double newval) {
        if(newval < Device::Info().limits_minFreq) {

--- a/Software/PC_Application/Generator/signalgenwidget.ui
+++ b/Software/PC_Application/Generator/signalgenwidget.ui
@@ -39,7 +39,7 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_4">
      <item>
-      <spacer name="verticalSpacer_2">
+      <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
@@ -52,20 +52,29 @@
       </spacer>
      </item>
      <item>
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Generator</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
-          <string>Generator</string>
+          <string>Frequency:</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Frequency:</string>
-            </property>
-           </widget>
-          </item>
           <item>
            <widget class="SIUnitEdit" name="frequency"/>
           </item>
@@ -148,7 +157,7 @@
       </layout>
      </item>
      <item>
-      <spacer name="verticalSpacer">
+      <spacer name="verticalSpacer_2">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>


### PR DESCRIPTION
Hi Jan!
I propose more digits in the frequency widget of signal gen.
And a slight modificaiton of ui panel. Just moved title "generator" to the top of the panel.

I am thinking also of changing the frequency input widget to double spin box. Maybe even to show both lineedit and double spin box, so users can change in both of them as they like. What do you think?
Zoran