### PR TITLE
Calibration save/load, gui cosmetics

### DIFF
--- a/Software/PC_Application/Calibration/calibration.cpp
+++ b/Software/PC_Application/Calibration/calibration.cpp
@@ -709,6 +709,7 @@ bool Calibration::openFromFile(QString filename)
         qWarning() << "Calibration file parsing failed: " << e.what();
         return false;
     }
+    this->currentCalFile = filename;    // if all ok, remember this and show on widget
 
     return true;
 }
@@ -741,6 +742,7 @@ bool Calibration::saveToFile(QString filename)
     auto calkit_file = filename + ".calkit";
     qDebug() << "Saving associated calibration kit to file" << calkit_file;
     kit.toFile(calkit_file);
+    this->currentCalFile = calibration_file;        // if all ok, remember this and show on widget
 
     return true;
 }
@@ -768,6 +770,10 @@ QString Calibration::hzToString(double freqHz){
         res = QString::number(freqHz / 1000000000, 'g', dgt) + "G";
     }
     return res;
+}
+
+QString Calibration::getCurrentCalibrationFile(){
+    return this->currentCalFile;
 }
 
 ostream& operator<<(ostream &os, const Calibration &c)

--- a/Software/PC_Application/Calibration/calibration.cpp
+++ b/Software/PC_Application/Calibration/calibration.cpp
@@ -709,7 +709,7 @@ bool Calibration::openFromFile(QString filename)
         qWarning() << "Calibration file parsing failed: " << e.what();
         return false;
     }
-    this->currentCalFile = filename;    // if all ok, remember this and show on widget
+    this->currentCalFile = filename;    // if all ok, remember this
 
     return true;
 }
@@ -717,7 +717,7 @@ bool Calibration::openFromFile(QString filename)
 bool Calibration::saveToFile(QString filename)
 {
     if(filename.isEmpty()) {
-        // suggest descriptive name
+        // Suggest descriptive name ie. "SOLT 40M-700M 1000pt"
         QString fn = Calibration::TypeToString(this->getType())
                 + " "
                 + hzToString(minFreq) + "-" + hzToString(maxFreq)
@@ -742,7 +742,7 @@ bool Calibration::saveToFile(QString filename)
     auto calkit_file = filename + ".calkit";
     qDebug() << "Saving associated calibration kit to file" << calkit_file;
     kit.toFile(calkit_file);
-    this->currentCalFile = calibration_file;        // if all ok, remember this and show on widget
+    this->currentCalFile = calibration_file;    // if all ok, remember this
 
     return true;
 }
@@ -750,7 +750,7 @@ bool Calibration::saveToFile(QString filename)
 /**
  * @brief Calibration::hzToString
  * @param freqHz - input frequency in Hz
- * @return frequency in human-readable form such as 145k 2M, 2.1M, 3.45G
+ * @return frequency in human-friendly form such as 145k 2M, 2.1M, 3.45G
  */
 QString Calibration::hzToString(double freqHz){
     int dgt = 3;        // how many significant digits

--- a/Software/PC_Application/Calibration/calibration.cpp
+++ b/Software/PC_Application/Calibration/calibration.cpp
@@ -679,7 +679,7 @@ bool Calibration::openFromFile(QString filename)
             return false;
         }
     }
-qDebug() << "Attempting to open calibration from file" << filename;
+    qDebug() << "Attempting to open calibration from file" << filename;
 
     // reset all data before loading new calibration
     clearMeasurements();
@@ -716,7 +716,14 @@ qDebug() << "Attempting to open calibration from file" << filename;
 bool Calibration::saveToFile(QString filename)
 {
     if(filename.isEmpty()) {
-        filename = QFileDialog::getSaveFileName(nullptr, "Save calibration data", "", "Calibration files (*.cal)", nullptr, QFileDialog::DontUseNativeDialog);
+        // suggest descriptive name
+        QString fn = Calibration::TypeToString(this->getType())
+                + " "
+                + hzToString(minFreq) + "-" + hzToString(maxFreq)
+                + " "
+                + QString::number(points.size()) + "pt";
+        //
+        filename = QFileDialog::getSaveFileName(nullptr, "Save calibration data", fn, "Calibration files (*.cal)", nullptr, QFileDialog::DontUseNativeDialog);
         if(filename.isEmpty()) {
             // aborted selection
             return false;
@@ -736,6 +743,31 @@ bool Calibration::saveToFile(QString filename)
     kit.toFile(calkit_file);
 
     return true;
+}
+
+/**
+ * @brief Calibration::hzToString
+ * @param freqHz - input frequency in Hz
+ * @return frequency in human-readable form such as 145k 2M, 2.1M, 3.45G
+ */
+QString Calibration::hzToString(double freqHz){
+    int dgt = 3;        // how many significant digits
+    QString res = "";   // initialize
+
+    if (freqHz <= 999) {
+        // 0-999Hz
+        res = QString::number(freqHz / 1, 'g', dgt) + "Hz";    // 1.23Hz, 45Hz, 88.5Hz
+    } else if (freqHz <= 999999) {
+        // 1k-999kHz
+        res = QString::number(freqHz / 1000, 'g', dgt) + "k";
+    } else if (freqHz <= 999999999) {
+        // 1M-999M
+        res = QString::number(freqHz / 1000000, 'g', dgt) + "M";
+    } else {
+        // 1G-...
+        res = QString::number(freqHz / 1000000000, 'g', dgt) + "G";
+    }
+    return res;
 }
 
 ostream& operator<<(ostream &os, const Calibration &c)

--- a/Software/PC_Application/Calibration/calibration.h
+++ b/Software/PC_Application/Calibration/calibration.h
@@ -138,6 +138,11 @@ private:
 
     Calkit kit;
     QString hzToString(double freqHz);
+
+private:
+    QString currentCalFile;
+public:
+    QString getCurrentCalibrationFile();
 };
 
 #endif // CALIBRATION_H

--- a/Software/PC_Application/Calibration/calibration.h
+++ b/Software/PC_Application/Calibration/calibration.h
@@ -137,6 +137,7 @@ private:
     std::vector<Point> points;
 
     Calkit kit;
+    QString hzToString(double freqHz);
 };
 
 #endif // CALIBRATION_H

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -287,7 +287,7 @@ VNA::VNA(AppWindow *window)
 
     // Calibration toolbar (and populate calibration menu)
     auto tb_cal = new QToolBar("Calibration");
-    QLabel *cbEnableCal_label = new QLabel("Calibration:");
+    QLabel *cbEnableCal_label = new QLabel("Calibration:");     // correct object type
     tb_cal->addWidget(cbEnableCal_label);
     auto cbEnableCal = new QCheckBox;
     tb_cal->addWidget(cbEnableCal);
@@ -327,8 +327,8 @@ VNA::VNA(AppWindow *window)
         cbEnableCal->blockSignals(true);
         calDisable->setChecked(true);
         cbEnableCal->setCheckState(Qt::CheckState::Unchecked);
-        cbEnableCal_label->setStyleSheet("background-color: yellow");
-        cbEnableCal_label->setToolTip("none");
+        cbEnableCal_label->setStyleSheet("background-color: yellow");       // visually indicate loss of calibration
+        cbEnableCal_label->setToolTip("none");                              // cal. file unknown at this moment
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(false);
@@ -346,8 +346,8 @@ VNA::VNA(AppWindow *window)
             }
         }
         cbEnableCal->setCheckState(Qt::CheckState::Checked);
-        cbEnableCal_label->setStyleSheet("");
-        cbEnableCal_label->setToolTip(cal.getCurrentCalibrationFile());
+        cbEnableCal_label->setStyleSheet("");                               // restore default look of widget
+        cbEnableCal_label->setToolTip(cal.getCurrentCalibrationFile());     // on hover, show name of active cal. file
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(true);

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -287,7 +287,8 @@ VNA::VNA(AppWindow *window)
 
     // Calibration toolbar (and populate calibration menu)
     auto tb_cal = new QToolBar("Calibration");
-    tb_cal->addWidget(new QLabel("Calibration:"));
+    auto cbEnableCal_label = new QLabel("Calibration:");
+    tb_cal->addWidget(cbEnableCal_label);
     auto cbEnableCal = new QCheckBox;
     tb_cal->addWidget(cbEnableCal);
     auto cbType = new QComboBox();
@@ -326,6 +327,7 @@ VNA::VNA(AppWindow *window)
         cbEnableCal->blockSignals(true);
         calDisable->setChecked(true);
         cbEnableCal->setCheckState(Qt::CheckState::Unchecked);
+        cbEnableCal_label->setStyleSheet("background-color: yellow");
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(false);
@@ -343,6 +345,7 @@ VNA::VNA(AppWindow *window)
             }
         }
         cbEnableCal->setCheckState(Qt::CheckState::Checked);
+        cbEnableCal_label->setStyleSheet("");
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(true);
@@ -427,7 +430,12 @@ void VNA::initializeDevice()
             if(cal.openFromFile(filename)) {
                 ApplyCalibration(cal.getType());
                 portExtension.setCalkit(&cal.getCalibrationKit());
+                qDebug() << "Calibration successful from " << filename;
+            } else {
+                qDebug() << "Calibration not successfull from: " << filename;
             }
+        } else {
+            qDebug() << "Calibration file not found: " << filename;
         }
         removeDefaultCal->setEnabled(true);
     } else {

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -287,7 +287,7 @@ VNA::VNA(AppWindow *window)
 
     // Calibration toolbar (and populate calibration menu)
     auto tb_cal = new QToolBar("Calibration");
-    auto cbEnableCal_label = new QLabel("Calibration:");
+    QLabel *cbEnableCal_label = new QLabel("Calibration:");
     tb_cal->addWidget(cbEnableCal_label);
     auto cbEnableCal = new QCheckBox;
     tb_cal->addWidget(cbEnableCal);
@@ -328,6 +328,7 @@ VNA::VNA(AppWindow *window)
         calDisable->setChecked(true);
         cbEnableCal->setCheckState(Qt::CheckState::Unchecked);
         cbEnableCal_label->setStyleSheet("background-color: yellow");
+        cbEnableCal_label->setToolTip("none");
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(false);
@@ -346,6 +347,7 @@ VNA::VNA(AppWindow *window)
         }
         cbEnableCal->setCheckState(Qt::CheckState::Checked);
         cbEnableCal_label->setStyleSheet("");
+        cbEnableCal_label->setToolTip(cal.getCurrentCalibrationFile());
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(true);

--- a/Software/PC_Application/preferences.cpp
+++ b/Software/PC_Application/preferences.cpp
@@ -163,6 +163,11 @@ void PreferencesDialog::setInitialGUIState()
     ui->GeneralGraphBackground->setColor(p->General.graphColors.background);
     ui->GeneralGraphAxis->setColor(p->General.graphColors.axis);
     ui->GeneralGraphDivisions->setColor(p->General.graphColors.divisions);
+
+    QTreeWidgetItem *item = ui->treeWidget->topLevelItem(0);
+    if (item != nullptr) {
+        ui->treeWidget->setCurrentItem(item);     // visually select first item
+    }
 }
 
 void Preferences::load()


### PR DESCRIPTION
Hello Jan!
I was playing with calibration and related stuff and I humbly :) propose some improvements:
calibration.cpp/h
- try to remember active cal.file name for later display
- suggest descriptive filename in "save calibration" dialog; created hzToString function to assist here. (I usually like to save my calibrations such as "cable abc, 40M-700M 400points", to distinguish from another cable e.g. "cable_xyz .... same as before". It gets a bit overwhelming if not precisely tracking wich cal file is which.) Anyway, the suggested filename is easy to delete by user, if they don't like it.

vna.cpp
- highlight "calibration" widget in yellow if calibration is not valid or not existing (any better idea?)
- show name of active cal.file if mouse hovered over widget (Couldn't think of a better place. Ideas, please?)
- slightly better logging if any problems during reading of cal.file

preferences.cpp
- when opening dialog, highlight first item in treeWidget

I have a couple other suggestions, but I would discuss with you first. One is related to calibration (remembering active cal. between switching modes). Would you like to discuss here or should I open another issue?
And a few other suggestions, about "ref" and "ref out" widgets, and dis/connection of device and calibration/interpolation... This definitely belongs in another issue(s). If you agree?

PS Sorry for using trace_math branch, I was stuck in it over the weekend and you are very fast in adding commits on your side... :-)

Zoran
