### PR TITLE
Calibration widget handling

### DIFF
--- a/Software/PC_Application/Calibration/calibration.cpp
+++ b/Software/PC_Application/Calibration/calibration.cpp
@@ -759,7 +759,8 @@ QString Calibration::descriptiveCalName(){
         hi = Unit::ToString(this->maxFreq, "", " kMG", precision);
     }
 
-    QString tmp = Calibration::TypeToString(this->getType())
+    QString tmp =
+            Calibration::TypeToString(this->getType())
             + " "
             + lo + "-" + hi
             + " "
@@ -767,6 +768,15 @@ QString Calibration::descriptiveCalName(){
     return tmp;
 }
 
+double Calibration::getMinFreq(){
+    return this->minFreq;
+}
+double Calibration::getMaxFreq(){
+    return this->maxFreq;
+}
+int Calibration::getNumPoints(){
+    return this->points.size();
+}
 QString Calibration::getCurrentCalibrationFile(){
     return this->currentCalFile;
 }

--- a/Software/PC_Application/Calibration/calibration.cpp
+++ b/Software/PC_Application/Calibration/calibration.cpp
@@ -709,6 +709,7 @@ bool Calibration::openFromFile(QString filename)
         qWarning() << "Calibration file parsing failed: " << e.what();
         return false;
     }
+    this->currentCalFile = filename;    // if all ok, remember this
 
     return true;
 }
@@ -716,7 +717,14 @@ bool Calibration::openFromFile(QString filename)
 bool Calibration::saveToFile(QString filename)
 {
     if(filename.isEmpty()) {
-        filename = QFileDialog::getSaveFileName(nullptr, "Save calibration data", "", "Calibration files (*.cal)", nullptr, QFileDialog::DontUseNativeDialog);
+        // Suggest descriptive name ie. "SOLT 40M-700M 1000pt"
+        QString fn = Calibration::TypeToString(this->getType())
+                + " "
+                + hzToString(minFreq) + "-" + hzToString(maxFreq)
+                + " "
+                + QString::number(points.size()) + "pt";
+        //
+        filename = QFileDialog::getSaveFileName(nullptr, "Save calibration data", fn, "Calibration files (*.cal)", nullptr, QFileDialog::DontUseNativeDialog);
         if(filename.isEmpty()) {
             // aborted selection
             return false;
@@ -734,8 +742,38 @@ bool Calibration::saveToFile(QString filename)
     auto calkit_file = filename + ".calkit";
     qDebug() << "Saving associated calibration kit to file" << calkit_file;
     kit.toFile(calkit_file);
+    this->currentCalFile = calibration_file;    // if all ok, remember this
 
     return true;
+}
+
+/**
+ * @brief Calibration::hzToString
+ * @param freqHz - input frequency in Hz
+ * @return frequency in human-friendly form such as 145k 2M, 2.1M, 3.45G
+ */
+QString Calibration::hzToString(double freqHz){
+    int dgt = 3;        // how many significant digits
+    QString res = "";   // initialize
+
+    if (freqHz <= 999) {
+        // 0-999Hz
+        res = QString::number(freqHz / 1, 'g', dgt) + "Hz";    // 1.23Hz, 45Hz, 88.5Hz
+    } else if (freqHz <= 999999) {
+        // 1k-999kHz
+        res = QString::number(freqHz / 1000, 'g', dgt) + "k";
+    } else if (freqHz <= 999999999) {
+        // 1M-999M
+        res = QString::number(freqHz / 1000000, 'g', dgt) + "M";
+    } else {
+        // 1G-...
+        res = QString::number(freqHz / 1000000000, 'g', dgt) + "G";
+    }
+    return res;
+}
+
+QString Calibration::getCurrentCalibrationFile(){
+    return this->currentCalFile;
 }
 
 ostream& operator<<(ostream &os, const Calibration &c)

--- a/Software/PC_Application/Calibration/calibration.h
+++ b/Software/PC_Application/Calibration/calibration.h
@@ -137,6 +137,12 @@ private:
     std::vector<Point> points;
 
     Calkit kit;
+    QString hzToString(double freqHz);
+
+private:
+    QString currentCalFile;
+public:
+    QString getCurrentCalibrationFile();
 };
 
 #endif // CALIBRATION_H

--- a/Software/PC_Application/Calibration/calibration.h
+++ b/Software/PC_Application/Calibration/calibration.h
@@ -137,7 +137,7 @@ private:
     std::vector<Point> points;
 
     Calkit kit;
-    QString hzToString(double freqHz);
+    QString descriptiveCalName();
 
 private:
     QString currentCalFile;

--- a/Software/PC_Application/Calibration/calibration.h
+++ b/Software/PC_Application/Calibration/calibration.h
@@ -143,6 +143,9 @@ private:
     QString currentCalFile;
 public:
     QString getCurrentCalibrationFile();
+    double getMinFreq();
+    double getMaxFreq();
+    int getNumPoints();
 };
 
 #endif // CALIBRATION_H

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -287,7 +287,7 @@ VNA::VNA(AppWindow *window)
 
     // Calibration toolbar (and populate calibration menu)
     auto tb_cal = new QToolBar("Calibration");
-    QLabel *cbEnableCal_label = new QLabel("Calibration:");     // correct object type
+    QLabel *cbEnableCal_label = new QLabel("Calibration:");
     tb_cal->addWidget(cbEnableCal_label);
     auto cbEnableCal = new QCheckBox;
     tb_cal->addWidget(cbEnableCal);
@@ -411,6 +411,7 @@ VNA::VNA(AppWindow *window)
 
     finalize(central);
 }
+
 
 void VNA::deactivate()
 {

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -287,7 +287,8 @@ VNA::VNA(AppWindow *window)
 
     // Calibration toolbar (and populate calibration menu)
     auto tb_cal = new QToolBar("Calibration");
-    tb_cal->addWidget(new QLabel("Calibration:"));
+    QLabel *cbEnableCal_label = new QLabel("Calibration:");     // correct object type
+    tb_cal->addWidget(cbEnableCal_label);
     auto cbEnableCal = new QCheckBox;
     tb_cal->addWidget(cbEnableCal);
     auto cbType = new QComboBox();
@@ -326,6 +327,8 @@ VNA::VNA(AppWindow *window)
         cbEnableCal->blockSignals(true);
         calDisable->setChecked(true);
         cbEnableCal->setCheckState(Qt::CheckState::Unchecked);
+        cbEnableCal_label->setStyleSheet("background-color: yellow");       // visually indicate loss of calibration
+        cbEnableCal_label->setToolTip("none");                              // cal. file unknown at this moment
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(false);
@@ -343,6 +346,8 @@ VNA::VNA(AppWindow *window)
             }
         }
         cbEnableCal->setCheckState(Qt::CheckState::Checked);
+        cbEnableCal_label->setStyleSheet("");                               // restore default look of widget
+        cbEnableCal_label->setToolTip(cal.getCurrentCalibrationFile());     // on hover, show name of active cal. file
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(true);
@@ -427,7 +432,12 @@ void VNA::initializeDevice()
             if(cal.openFromFile(filename)) {
                 ApplyCalibration(cal.getType());
                 portExtension.setCalkit(&cal.getCalibrationKit());
+                qDebug() << "Calibration successful from " << filename;
+            } else {
+                qDebug() << "Calibration not successfull from: " << filename;
             }
+        } else {
+            qDebug() << "Calibration file not found: " << filename;
         }
         removeDefaultCal->setEnabled(true);
     } else {

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -288,7 +288,7 @@ VNA::VNA(AppWindow *window)
     // Calibration toolbar (and populate calibration menu)
     auto tb_cal = new QToolBar("Calibration");
     QLabel *cbEnableCal_label = new QLabel("Calibration:");
-    cbEnableCal_label->setStyleSheet(getCalStyleStr());                         // on app start
+    cbEnableCal_label->setStyleSheet(getCalStyle());                         // on app start
     cbEnableCal_label->setToolTip(getCalToolTip());                             // no cal. file loaded
     tb_cal->addWidget(cbEnableCal_label);
     auto cbEnableCal = new QCheckBox;
@@ -329,7 +329,7 @@ VNA::VNA(AppWindow *window)
         cbEnableCal->blockSignals(true);
         calDisable->setChecked(true);
         cbEnableCal->setCheckState(Qt::CheckState::Unchecked);
-        cbEnableCal_label->setStyleSheet(getCalStyleStr());                     // visually indicate loss of calibration
+        cbEnableCal_label->setStyleSheet(getCalStyle());                     // visually indicate loss of calibration
         cbEnableCal_label->setToolTip(getCalToolTip());                         // cal. file unknown at this moment
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
@@ -348,7 +348,7 @@ VNA::VNA(AppWindow *window)
             }
         }
         cbEnableCal->setCheckState(Qt::CheckState::Checked);
-        cbEnableCal_label->setStyleSheet(getCalStyleStr());                     // restore default look of widget
+        cbEnableCal_label->setStyleSheet(getCalStyle());                     // restore default look of widget
         cbEnableCal_label->setToolTip(getCalToolTip());                         // on hover, show name of active cal. file
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
@@ -414,7 +414,7 @@ VNA::VNA(AppWindow *window)
     finalize(central);
 }
 
-QString VNA::getCalStyleStr()
+QString VNA::getCalStyle()
 {
     Calibration::InterpolationType interpol = cal.getInterpolation(settings);
     QString style = "";
@@ -446,8 +446,19 @@ QString VNA::getCalToolTip()
     case Calibration::InterpolationType::Exact:
     case Calibration::InterpolationType::Interpolate:
     case Calibration::InterpolationType::Extrapolate:
-        txt = cal.getCurrentCalibrationFile();
+    {
+        QString lo = Unit::ToString(cal.getMinFreq(), "", " kMG", 5);
+        QString hi = Unit::ToString(cal.getMaxFreq(), "", " kMG", 5);
+        if (settings.f_start < cal.getMinFreq() ) { lo = "<font color=\"red\">" + lo + "</font>";}
+        if (settings.f_stop > cal.getMaxFreq() ) { hi = "<font color=\"red\">" + hi + "</font>";}
+        txt =
+                "limits: " + lo + " - " + hi
+                + "<br>"
+                + "points: " + QString::number(cal.getNumPoints())
+                + "<br>"
+                "file: " + cal.getCurrentCalibrationFile();
         break;
+    }
     case Calibration::InterpolationType::NoCalibration:
         txt = "none";
         break;

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -288,6 +288,8 @@ VNA::VNA(AppWindow *window)
     // Calibration toolbar (and populate calibration menu)
     auto tb_cal = new QToolBar("Calibration");
     QLabel *cbEnableCal_label = new QLabel("Calibration:");
+    cbEnableCal_label->setStyleSheet(getCalStyleStr());                         // on app start
+    cbEnableCal_label->setToolTip(getCalToolTip());                             // no cal. file loaded
     tb_cal->addWidget(cbEnableCal_label);
     auto cbEnableCal = new QCheckBox;
     tb_cal->addWidget(cbEnableCal);
@@ -327,8 +329,8 @@ VNA::VNA(AppWindow *window)
         cbEnableCal->blockSignals(true);
         calDisable->setChecked(true);
         cbEnableCal->setCheckState(Qt::CheckState::Unchecked);
-        cbEnableCal_label->setStyleSheet("background-color: yellow");       // visually indicate loss of calibration
-        cbEnableCal_label->setToolTip("none");                              // cal. file unknown at this moment
+        cbEnableCal_label->setStyleSheet(getCalStyleStr());                     // visually indicate loss of calibration
+        cbEnableCal_label->setToolTip(getCalToolTip());                         // cal. file unknown at this moment
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(false);
@@ -346,8 +348,8 @@ VNA::VNA(AppWindow *window)
             }
         }
         cbEnableCal->setCheckState(Qt::CheckState::Checked);
-        cbEnableCal_label->setStyleSheet("");                               // restore default look of widget
-        cbEnableCal_label->setToolTip(cal.getCurrentCalibrationFile());     // on hover, show name of active cal. file
+        cbEnableCal_label->setStyleSheet(getCalStyleStr());                     // restore default look of widget
+        cbEnableCal_label->setToolTip(getCalToolTip());                         // on hover, show name of active cal. file
         cbType->blockSignals(false);
         cbEnableCal->blockSignals(false);
         calImportTerms->setEnabled(true);
@@ -412,6 +414,46 @@ VNA::VNA(AppWindow *window)
     finalize(central);
 }
 
+QString VNA::getCalStyleStr()
+{
+    Calibration::InterpolationType interpol = cal.getInterpolation(settings);
+    QString style = "";
+    switch (interpol)
+    {
+    case Calibration::InterpolationType::Unchanged:
+    case Calibration::InterpolationType::Exact:
+    case Calibration::InterpolationType::Interpolate:
+        style = "";
+        break;
+
+    case Calibration::InterpolationType::Extrapolate:
+        style = "background-color: yellow";
+        break;
+    case Calibration::InterpolationType::NoCalibration:
+        style = "background-color: red";
+        break;
+    }
+    return style;
+}
+
+QString VNA::getCalToolTip()
+{
+    Calibration::InterpolationType interpol = cal.getInterpolation(settings);
+    QString txt = "";
+    switch (interpol)
+    {
+    case Calibration::InterpolationType::Unchanged:
+    case Calibration::InterpolationType::Exact:
+    case Calibration::InterpolationType::Interpolate:
+    case Calibration::InterpolationType::Extrapolate:
+        txt = cal.getCurrentCalibrationFile();
+        break;
+    case Calibration::InterpolationType::NoCalibration:
+        txt = "none";
+        break;
+    }
+    return txt;
+}
 
 void VNA::deactivate()
 {

--- a/Software/PC_Application/VNA/vna.h
+++ b/Software/PC_Application/VNA/vna.h
@@ -71,6 +71,7 @@ private:
     bool calWaitFirst;
     QProgressDialog calDialog;
 
+
     QMenu *defaultCalMenu;
     QAction *assignDefaultCal, *removeDefaultCal;
     QAction *saveCal;

--- a/Software/PC_Application/VNA/vna.h
+++ b/Software/PC_Application/VNA/vna.h
@@ -70,6 +70,8 @@ private:
     bool calMeasuring;
     bool calWaitFirst;
     QProgressDialog calDialog;
+    QString getCalStyleStr();
+    QString getCalToolTip();
 
 
     QMenu *defaultCalMenu;

--- a/Software/PC_Application/VNA/vna.h
+++ b/Software/PC_Application/VNA/vna.h
@@ -70,7 +70,7 @@ private:
     bool calMeasuring;
     bool calWaitFirst;
     QProgressDialog calDialog;
-    QString getCalStyleStr();
+    QString getCalStyle();
     QString getCalToolTip();
 
 

--- a/Software/PC_Application/preferences.cpp
+++ b/Software/PC_Application/preferences.cpp
@@ -163,6 +163,11 @@ void PreferencesDialog::setInitialGUIState()
     ui->GeneralGraphBackground->setColor(p->General.graphColors.background);
     ui->GeneralGraphAxis->setColor(p->General.graphColors.axis);
     ui->GeneralGraphDivisions->setColor(p->General.graphColors.divisions);
+
+    QTreeWidgetItem *item = ui->treeWidget->topLevelItem(0);
+    if (item != nullptr) {
+        ui->treeWidget->setCurrentItem(item);     // visually select first item
+    }
 }
 
 void Preferences::load()


### PR DESCRIPTION
Sorry for the other one :(  this should be the right pull request. I've gotta' stop working so late!
As you have more experience, please please, check if this includes the other one, plus my tonight's changes. Then kindly reject...

So here is the text again:

Good morning!
Here is my attempt at some of your suggestions. 

- When starting the application and no calibration is in use...
- Displaying the filename in the tooltip...

Well, the simplest option would be to show the same hint as it is now "bla bla 100M - 600M 1000pt", where the "600M" would be also yellow, assuming this is the limit which was crossed. But I don't see that styling parts of the tooltip text is possible. Am I right? Also, this approach is not very obvious for the user, so I'm not quite happy about it. 

So in parallel, I was thinking to add a QToolButton ![image](https://user-images.githubusercontent.com/60575976/101306746-018fce80-3846-11eb-88d2-06e4d67d61e8.png)  or this little thing ![image](https://user-images.githubusercontent.com/60575976/101306777-1a987f80-3846-11eb-9871-7116918937de.png)  and in case if interpolation turns yellow or red, the user would already have an idea to click or hover there. 
Ideally, the widget, the checkbox and combobox would be in a class of itself so the vna.cpp would be cleaner. I would love this, but wow, I would have to experiment heavily for that! :) Don't forget I am still learning Qt...

So much for the graphical look. I will be happy to hear your suggestions on this.

Regarding the initial state and changing during operation, I am definitely missing something. When app starts, the widget is initially red, but after changing start or stop of the sweep, nothing happens. Saving or loading the cal file works ok, but I was aiming to make it change as the start, stop, span... in the sweep toolbar are changing. In **VNA::getCalStyleStr()** and **VNA::getCalToolTip()** you would see the logic
cal type is extrapolation -> yellow
no cal -> red
all other cases -> revert to 'original' look (for types: no change, interpolation, exact)
Again, I would try to make this in a separate class, but at first it has to work from here. Probably I didn't catch the right signals or something like that. Kindly asking for help here, and/or suggestion on what to look for.


- I would prefer the usage of Unit::ToString

At least I got this one right! :-) 
By the way, what are 2nd and 3rd parameters for Unit::ToString() ? Am I using it correctly?

By the way, a great THANKS for saving/restoring the state of the panels/tiles! This was an idea for a long time... Another thought on this: when you leave only one chart on the screen, how to add another one? The only way I find is to delete the last remaining chart, and then the tile widget allows you to split the screen again. But then you loose all the settings such as span and x-y axes for the deleted chart. Am I right?

Final thought: I was kind'a lost in my local repo after you deleted the tracemath branch, so I had play with it and (re)clone several times until able to keep/merge my own changes from before, and continue from there. This is not a complaint, for sure! :) On the contrary, I am just hoping my pull request is now showing up correctly on your side. Let me know!

Zoran
