### PR TITLE
Reference clock widgets - consolidation #17

### DIFF
--- a/Software/PC_Application/Traces/tracemarker.cpp
+++ b/Software/PC_Application/Traces/tracemarker.cpp
@@ -11,7 +11,7 @@
 using namespace std;
 
 TraceMarker::TraceMarker(TraceMarkerModel *model, int number, TraceMarker *parent, QString descr)
-    : editingFrequeny(false),
+    : editingFrequency(false),
       model(model),
       parentTrace(nullptr),
       position(1000000000),

--- a/Software/PC_Application/Traces/tracemarker.h
+++ b/Software/PC_Application/Traces/tracemarker.h
@@ -33,7 +33,7 @@ public:
     int getNumber() const;
     void setNumber(int value);
 
-    bool editingFrequeny;
+    bool editingFrequency;
     Trace *getTrace() const;
 
     enum class Type {

--- a/Software/PC_Application/Traces/tracemarkermodel.cpp
+++ b/Software/PC_Application/Traces/tracemarkermodel.cpp
@@ -88,11 +88,15 @@ void TraceMarkerModel::addMarker(TraceMarker *t)
     connect(t, &TraceMarker::beginRemoveHelperMarkers, [=](TraceMarker *m) {
          auto row = find(markers.begin(), markers.end(), m) - markers.begin();
          auto modelIndex = createIndex(row, 0, root);
-         beginRemoveRows(modelIndex, 0, m->getHelperMarkers().size() - 1);
+         if(!m->getHelperMarkers().empty()){
+             beginRemoveRows(modelIndex, 0, m->getHelperMarkers().size() - 1);
+         }
     });
     connect(t, &TraceMarker::endRemoveHelperMarkers, [=](TraceMarker *m) {
         markerDataChanged(m);
-        endRemoveRows();
+        if(!m->getHelperMarkers().empty()){
+            endRemoveRows();
+        }
     });
     connect(t, &TraceMarker::deleted, this, qOverload<TraceMarker*>(&TraceMarkerModel::removeMarker));
     emit markerAdded(t);
@@ -118,7 +122,7 @@ void TraceMarkerModel::removeMarker(TraceMarker *m)
 void TraceMarkerModel::markerDataChanged(TraceMarker *m)
 {
     auto row = find(markers.begin(), markers.end(), m) - markers.begin();
-    if(m->editingFrequeny) {
+    if(m->editingFrequency) {
         // only update the other columns, do not override editor data
         emit dataChanged(index(row, ColIndexData), index(row, ColIndexData));
     } else {
@@ -373,14 +377,14 @@ QSize MarkerSettingsDelegate::sizeHint(const QStyleOptionViewItem &, const QMode
 QWidget *MarkerSettingsDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const
 {
     auto marker = static_cast<const TraceMarkerModel*>(index.model())->markerFromIndex(index);
-    marker->editingFrequeny = true;
+    marker->editingFrequency = true;
     auto e = marker->getSettingsEditor();
     if(e) {
         e->setMaximumHeight(rowHeight);
         e->setParent(parent);
         connect(e, &SIUnitEdit::valueUpdated, this, &MarkerSettingsDelegate::commitData);
         connect(e, &SIUnitEdit::focusLost, [=](){
-            marker->editingFrequeny = false;
+            marker->editingFrequency = false;
         });
     }
     return e;

--- a/Software/PC_Application/appwindow.cpp
+++ b/Software/PC_Application/appwindow.cpp
@@ -277,30 +277,21 @@ void AppWindow::CreateToolbars()
 {
     // Reference toolbar
     auto tb_reference = new QToolBar("Reference", this);
-    tb_reference->addWidget(new QLabel("Ref:"));
+    tb_reference->addWidget(new QLabel("Ref in:"));
     toolbars.reference.type = new QComboBox();
     toolbars.reference.type->addItem("Int");
     toolbars.reference.type->addItem("Ext");
-    toolbars.reference.automatic = new QCheckBox("Auto");
-    connect(toolbars.reference.automatic, &QCheckBox::clicked, [this](bool checked) {
-        toolbars.reference.type->setEnabled(!checked);
-        UpdateReference();
-    });
-    //    toolbars.reference.automatic->setChecked(true);
+    toolbars.reference.type->addItem("Auto");
     tb_reference->addWidget(toolbars.reference.type);
-    tb_reference->addWidget(toolbars.reference.automatic);
     tb_reference->addSeparator();
     tb_reference->addWidget(new QLabel("Ref out:"));
-    toolbars.reference.outputEnabled = new QCheckBox();
     toolbars.reference.outFreq = new QComboBox();
+    toolbars.reference.outFreq->addItem("Off");
     toolbars.reference.outFreq->addItem("10 MHz");
     toolbars.reference.outFreq->addItem("100 MHz");
-    tb_reference->addWidget(toolbars.reference.outputEnabled);
     tb_reference->addWidget(toolbars.reference.outFreq);
     connect(toolbars.reference.type, qOverload<int>(&QComboBox::currentIndexChanged), this, &AppWindow::UpdateReference);
     connect(toolbars.reference.outFreq, qOverload<int>(&QComboBox::currentIndexChanged), this, &AppWindow::UpdateReference);
-    connect(toolbars.reference.outputEnabled, &QCheckBox::clicked, this, &AppWindow::UpdateReference);
-
     addToolBar(tb_reference);
     tb_reference->setObjectName("Reference Toolbar");
 }
@@ -352,22 +343,23 @@ void AppWindow::UpdateReference()
         return;
     }
     Protocol::ReferenceSettings s = {};
-    if(toolbars.reference.automatic->isChecked()) {
-        s.AutomaticSwitch = 1;
-    }
-    if(toolbars.reference.type->currentText()=="Ext") {
+
+    QString txt1 = toolbars.reference.type->currentText();
+    if( (txt1=="Ext") || (txt1=="External") ) {
         s.UseExternalRef = 1;
     }
-    if(toolbars.reference.outputEnabled->isChecked()) {
-        switch(toolbars.reference.outFreq->currentIndex()) {
-        case 0:
-            s.ExtRefOuputFreq = 10000000;
-            break;
-        case 1:
-            s.ExtRefOuputFreq = 100000000;
-            break;
-        }
+    if( (txt1=="Auto") || (txt1=="Automatic") ) {
+        s.AutomaticSwitch = 1;
     }
+
+    QString txt2 = toolbars.reference.outFreq->currentText();
+    if(txt2=="10 MHz"){
+        s.ExtRefOuputFreq = 10000000;
+    }
+    if(txt2=="100 MHz"){
+        s.ExtRefOuputFreq = 100000000;
+    }
+
     Protocol::PacketInfo p;
     p.type = Protocol::PacketType::Reference;
     p.reference = s;

--- a/Software/PC_Application/appwindow.h
+++ b/Software/PC_Application/appwindow.h
@@ -61,8 +61,6 @@ private:
     struct {
         struct {
             QComboBox *type;
-            QCheckBox *automatic;
-            QCheckBox *outputEnabled;
             QComboBox *outFreq;
         } reference;
     } toolbars;


### PR DESCRIPTION
Jan, good morning once again!
I made some changes according to https://github.com/jankae/VNA2/issues/17#issue-758466939
I believe it's ok but I found two crash instances along the way. 
For clarity, I opened one issue, and continued the other:
https://github.com/jankae/VNA2/issues/18#issue-760862785 Corrected. Almost. Still an occasional crash in a very specific situation. I'm stuck. Please check further.
https://github.com/jankae/VNA2/issues/17#issuecomment-742229782 Device gets locked when reference is set to external. I'm pretty sure this did not happen in some early commits because I was playing with it several times. 

Regarding this pull request, it was easy. I changed one combo box check from 'current position' to string literal. It is safer if we change the order of strings accidentaly (as I did). Along the way, I tried to make some kind of enum for triggering and checking combo box current position. Would be safer against typos' or lower/upper case changes. But it would have to associate both an int and a string. I've done this in java once but not in c++, so let's leave that exercise to have fun in the future. 
Cheers my friend! As I dig more deeply into code, I have more and more admiration. It's no joke ;-)

Zoran

